### PR TITLE
Add rbac example and docs for kubernetes deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,10 @@ $ kubectl create secret generic bugsnag --from-literal=api-key=MYSECRETAPIKEY
 ```
 
 To enable Statsd reporting, set `STATSD_URL` in your ENV.
-The included sample deployment YAML expects this to be `statsd:8125` (you have a service named statsd running on UDP 8125). 
+The included sample deployment YAML expects this to be `statsd:8125` (you have a service named statsd running on UDP 8125).
+
+## Permissions 
+
+You have to create a service account in your cluster and grant permissions to it, in order to list and watch
+events with the logger. To do so, create service account, clusterrole and binding as shown in the deploymnet folder in
+this repo.

--- a/deployments/k8s-event-logger.yaml.erb
+++ b/deployments/k8s-event-logger.yaml.erb
@@ -10,6 +10,7 @@ spec:
       labels:
         app: k8s-event-logger
     spec:
+      serviceAccountName: k8s-event-logger
       containers:
       - name: k8s-event-logger
         image: dubs/k8s-event-logger:<%= ENV["SHA"] || "latest" %>

--- a/deployments/rbac.yaml.erb
+++ b/deployments/rbac.yaml.erb
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8s-event-logger
+  labels:
+    app: k8s-event-logger 
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: k8s-event-logger 
+  labels:
+    app: k8s-event-logger 
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "events"
+  verbs: ["list", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: kube-system
+  name: k8s-event-logger 
+  labels:
+    app: k8s-event-logger 
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+subjects:
+- kind: ServiceAccount
+  name: k8s-event-logger 
+  namespace: kube-system
+  apiGroup: ""
+roleRef:
+  kind: ClusterRole
+  name: k8s-event-logger 


### PR DESCRIPTION
This pr add an example rbac file and a comment in readme to provide informations about needed permissions.